### PR TITLE
pin bundler version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,7 @@ runs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2 # Not needed with a .ruby-version file
+        bundler: 2.4.22
 
     - name: Cache Ruby Gems
       uses: actions/cache@v3


### PR DESCRIPTION
**Issue**: CI checks started failing randomly at ruby bundler installation step

**Root Cause**: Unpinned bundler version. Ruby bundler above v2.4.22 doesn't support ruby v2.7.4.

**Solution**: Pin bundler version to support existing ruby version.


_Creating a fork since original project doesn't seemed to be active anymore_

<img width="1033" alt="image" src="https://github.com/lewagon/wait-on-check-action/assets/43565572/e9eaac8d-4d01-4fe1-9ea8-62511f71d3a4">